### PR TITLE
Add gNMI container wait logic to teardown for reboot tests

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -197,6 +197,30 @@ def wait_for_startup(duthost, localhost, delay, timeout):
 
     logger.info('ssh has started up on {}'.format(hostname))
 
+def wait_for_gnmi_container(duthost, timeout=300, interval=10):
+    """
+    Waits for the gNMI container to be in a running state.
+
+    :param duthost: The DUT host object
+    :param timeout: Maximum time to wait for the container (in seconds)
+    :param interval: Time interval between each check (in seconds)
+    :return: True if the container is up, False otherwise
+    """
+    elapsed_time = 0
+    while elapsed_time < timeout:
+        # Check if gNMI container is running
+        output = duthost.shell("docker inspect -f '{{ '{{' }} .State.Status {{ '}}' }}' gnmi 2>/dev/null")['stdout_lines']
+
+        if "running" in str(output).lower():
+            logging.info("gNMI container is running.")
+            return True
+
+        logging.warning("gNMI container not found in running state. Retrying in {}s...".format(interval))
+        time.sleep(interval)
+        elapsed_time += interval
+
+    logging.error("Timeout: gNMI container did not start within {} seconds!".format(timeout))
+    return False
 
 def perform_reboot(duthost, pool, reboot_command, reboot_helper=None, reboot_kwargs=None, reboot_type='cold'):
     # pool for executing tasks asynchronously


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Ensure gNMI Container is Running Before Proceeding with Reboots.

Summary:
1. Added wait_for_gnmi_container() function in tests/common/reboot.py
This function checks if the gNMI container is in a running state before proceeding.
It retries at regular intervals (default: 10s) for a maximum timeout (default: 300s).
If the container does not start within the timeout, the function logs an error and returns False.

2. Updated gNOI system reboot test cases in tests/gnmi/test_gnoi_system.py
Modified test_gnoi_system_reboot, test_gnoi_system_reboot_when_reboot_active, test_gnoi_system_reboot_status_immediately, and test_gnoi_system_reboot_status_after_startup to:
Wait for DUT to fully start up and gNMI container to restart before proceeding with further checks. And, Fail the test early if the gNMI container fails to restart within the expected time.
This ensures test stability by verifying that the gNMI container is operational post-reboot.

Previously, the tests assumed that the gNMI container would always be available after a reboot. However, if the container fails to restart, subsequent test steps could produce misleading failures.
This change improves reliability by explicitly ensuring that the gNMI container is running before proceeding.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
