### PR TITLE
Add PoC gNMI test using new TLS fixture with legacy client

### DIFF
--- a/tests/gnmi/test_gnmi_configdb_new.py
+++ b/tests/gnmi/test_gnmi_configdb_new.py
@@ -1,6 +1,12 @@
+import base64
 import json
 import logging
 import pytest
+
+# Import fixtures to ensure pytest discovers them
+from tests.common.fixtures.grpc_fixtures import (  # noqa: F401
+    setup_gnoi_tls_server, ptf_grpc
+)
 
 logger = logging.getLogger(__name__)
 
@@ -29,13 +35,11 @@ def gnmi_path_to_proto(path_str):
             ]
         }
     """
-    # Strip origin prefix if present
     origin = ""
     if ":" in path_str.split("/")[1]:
         prefix, path_str = path_str.split(":", 1)
         origin = prefix.lstrip("/")
 
-    # Split remaining path into elements, skip empty
     elems = [{"name": seg} for seg in path_str.split("/") if seg]
 
     path = {"elem": elems}
@@ -44,13 +48,10 @@ def gnmi_path_to_proto(path_str):
     return path
 
 
-def test_gnmi_configdb_get_metadata(duthosts, rand_one_dut_hostname, ptf_grpc):
+def test_gnmi_configdb_get_metadata(ptf_grpc):  # noqa: F811
     """
     Verify gNMI Get for CONFIG_DB DEVICE_METADATA using new grpcurl-based fixture.
     """
-    duthost = duthosts[rand_one_dut_hostname]
-
-    # Build gNMI GetRequest
     path = gnmi_path_to_proto("/sonic-db:CONFIG_DB/localhost/DEVICE_METADATA/localhost")
     request = {
         "path": [path],
@@ -61,27 +62,21 @@ def test_gnmi_configdb_get_metadata(duthosts, rand_one_dut_hostname, ptf_grpc):
     response = ptf_grpc.call_unary("gnmi.gNMI", "Get", request)
     logger.info("gNMI Get response: %s", json.dumps(response))
 
-    # Verify response contains notification with updates
     assert "notification" in response, "Missing 'notification' in GetResponse: %s" % response
     notifications = response["notification"]
     assert len(notifications) > 0, "Empty notifications in GetResponse"
 
-    # Extract the value from the first notification's first update
     updates = notifications[0].get("update", [])
     assert len(updates) > 0, "No updates in notification: %s" % notifications[0]
 
-    # The val should contain DEVICE_METADATA fields including bgp_asn
     val = updates[0].get("val", {})
     json_val = val.get("jsonIetfVal", "")
     if json_val:
-        # grpcurl returns base64-encoded bytes for jsonIetfVal
-        import base64
         decoded = base64.b64decode(json_val).decode("utf-8")
         result = json.loads(decoded)
     else:
         result = val
 
     logger.info("Decoded value: %s", result)
-    # Check for bgp_asn in the result (could be nested under "localhost" or flat)
     result_str = json.dumps(result)
     assert "bgp_asn" in result_str, "bgp_asn not found in GetResponse value: %s" % result_str

--- a/tests/gnmi/test_gnmi_configdb_new.py
+++ b/tests/gnmi/test_gnmi_configdb_new.py
@@ -1,0 +1,87 @@
+import json
+import logging
+import pytest
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.usefixtures("setup_gnmi_ntp_client_server", "setup_gnoi_tls_server",
+                            "check_dut_timestamp")
+]
+
+
+def gnmi_path_to_proto(path_str):
+    """
+    Convert a sonic-db gNMI path string to a gNMI Path proto dict.
+
+    Example:
+        "/sonic-db:CONFIG_DB/localhost/DEVICE_METADATA/localhost"
+        ->
+        {
+            "origin": "sonic-db",
+            "elem": [
+                {"name": "CONFIG_DB"},
+                {"name": "localhost"},
+                {"name": "DEVICE_METADATA"},
+                {"name": "localhost"}
+            ]
+        }
+    """
+    # Strip origin prefix if present
+    origin = ""
+    if ":" in path_str.split("/")[1]:
+        prefix, path_str = path_str.split(":", 1)
+        origin = prefix.lstrip("/")
+
+    # Split remaining path into elements, skip empty
+    elems = [{"name": seg} for seg in path_str.split("/") if seg]
+
+    path = {"elem": elems}
+    if origin:
+        path["origin"] = origin
+    return path
+
+
+def test_gnmi_configdb_get_metadata(duthosts, rand_one_dut_hostname, ptf_grpc):
+    """
+    Verify gNMI Get for CONFIG_DB DEVICE_METADATA using new grpcurl-based fixture.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    # Build gNMI GetRequest
+    path = gnmi_path_to_proto("/sonic-db:CONFIG_DB/localhost/DEVICE_METADATA/localhost")
+    request = {
+        "path": [path],
+        "encoding": "JSON_IETF"
+    }
+
+    logger.info("Sending gNMI Get request: %s", json.dumps(request))
+    response = ptf_grpc.call_unary("gnmi.gNMI", "Get", request)
+    logger.info("gNMI Get response: %s", json.dumps(response))
+
+    # Verify response contains notification with updates
+    assert "notification" in response, "Missing 'notification' in GetResponse: %s" % response
+    notifications = response["notification"]
+    assert len(notifications) > 0, "Empty notifications in GetResponse"
+
+    # Extract the value from the first notification's first update
+    updates = notifications[0].get("update", [])
+    assert len(updates) > 0, "No updates in notification: %s" % notifications[0]
+
+    # The val should contain DEVICE_METADATA fields including bgp_asn
+    val = updates[0].get("val", {})
+    json_val = val.get("jsonIetfVal", "")
+    if json_val:
+        # grpcurl returns base64-encoded bytes for jsonIetfVal
+        import base64
+        decoded = base64.b64decode(json_val).decode("utf-8")
+        result = json.loads(decoded)
+    else:
+        result = val
+
+    logger.info("Decoded value: %s", result)
+    # Check for bgp_asn in the result (could be nested under "localhost" or flat)
+    result_str = json.dumps(result)
+    assert "bgp_asn" in result_str, "bgp_asn not found in GetResponse value: %s" % result_str

--- a/tests/gnmi/test_gnmi_configdb_new.py
+++ b/tests/gnmi/test_gnmi_configdb_new.py
@@ -1,12 +1,12 @@
-import base64
-import json
 import logging
 import pytest
 
-# Import fixtures to ensure pytest discovers them
 from tests.common.fixtures.grpc_fixtures import (  # noqa: F401
     setup_gnoi_tls_server, ptf_grpc
 )
+from tests.common.grpc_config import grpc_config
+from .helper import gnmi_get
+from tests.common.helpers.assertions import pytest_assert
 
 logger = logging.getLogger(__name__)
 
@@ -14,69 +14,39 @@ pytestmark = [
     pytest.mark.topology('any'),
     pytest.mark.disable_loganalyzer,
     pytest.mark.usefixtures("setup_gnmi_ntp_client_server", "setup_gnoi_tls_server",
-                            "check_dut_timestamp")
+                            "setup_legacy_cert_paths", "check_dut_timestamp")
 ]
 
 
-def gnmi_path_to_proto(path_str):
+@pytest.fixture(scope="module")
+def setup_legacy_cert_paths(ptfhost):
     """
-    Convert a sonic-db gNMI path string to a gNMI Path proto dict.
+    Create symlinks from new cert paths to legacy paths expected by py_gnmicli.
 
-    Example:
-        "/sonic-db:CONFIG_DB/localhost/DEVICE_METADATA/localhost"
-        ->
-        {
-            "origin": "sonic-db",
-            "elem": [
-                {"name": "CONFIG_DB"},
-                {"name": "localhost"},
-                {"name": "DEVICE_METADATA"},
-                {"name": "localhost"}
-            ]
-        }
+    The new TLS fixture places certs at /etc/ssl/certs/gnmi*.cer,
+    but the old gnmi_get helper expects /root/gnmiCA.pem, /root/gnmiclient.crt, etc.
     """
-    origin = ""
-    if ":" in path_str.split("/")[1]:
-        prefix, path_str = path_str.split(":", 1)
-        origin = prefix.lstrip("/")
+    links = [
+        (grpc_config.get_ptf_cert_paths()['ca_cert'], "/root/gnmiCA.pem"),
+        (grpc_config.get_ptf_cert_paths()['client_cert'], "/root/gnmiclient.crt"),
+        (grpc_config.get_ptf_cert_paths()['client_key'], "/root/gnmiclient.key"),
+    ]
+    for src, dst in links:
+        ptfhost.shell("ln -sf %s %s" % (src, dst), module_ignore_errors=True)
 
-    elems = [{"name": seg} for seg in path_str.split("/") if seg]
+    yield
 
-    path = {"elem": elems}
-    if origin:
-        path["origin"] = origin
-    return path
+    for _, dst in links:
+        ptfhost.shell("rm -f %s" % dst, module_ignore_errors=True)
 
 
-def test_gnmi_configdb_get_metadata(ptf_grpc):  # noqa: F811
+def test_gnmi_configdb_get_metadata(duthosts, rand_one_dut_hostname, ptfhost):
     """
-    Verify gNMI Get for CONFIG_DB DEVICE_METADATA using new grpcurl-based fixture.
+    Verify gNMI Get for CONFIG_DB DEVICE_METADATA using new TLS fixture.
     """
-    path = gnmi_path_to_proto("/sonic-db:CONFIG_DB/localhost/DEVICE_METADATA/localhost")
-    request = {
-        "path": [path],
-        "encoding": "JSON_IETF"
-    }
-
-    logger.info("Sending gNMI Get request: %s", json.dumps(request))
-    response = ptf_grpc.call_unary("gnmi.gNMI", "Get", request)
-    logger.info("gNMI Get response: %s", json.dumps(response))
-
-    assert "notification" in response, "Missing 'notification' in GetResponse: %s" % response
-    notifications = response["notification"]
-    assert len(notifications) > 0, "Empty notifications in GetResponse"
-
-    updates = notifications[0].get("update", [])
-    assert len(updates) > 0, "No updates in notification: %s" % notifications[0]
-
-    val = updates[0].get("val", {})
-    json_val = val.get("jsonIetfVal", "")
-    if json_val:
-        decoded = base64.b64decode(json_val).decode("utf-8")
-        result = json.loads(decoded)
-    else:
-        result = val
-
-    logger.info("Decoded value: %s", result)
-    result_str = json.dumps(result)
-    assert "bgp_asn" in result_str, "bgp_asn not found in GetResponse value: %s" % result_str
+    duthost = duthosts[rand_one_dut_hostname]
+    path_list = ["/sonic-db:CONFIG_DB/localhost/DEVICE_METADATA/localhost"]
+    msg_list = gnmi_get(duthost, ptfhost, path_list)
+    pytest_assert(len(msg_list) > 0, "No response from gNMI Get")
+    result = msg_list[0]
+    pytest_assert("bgp_asn" in result, "bgp_asn not found in GetResponse: %s" % result)


### PR DESCRIPTION
### Description of PR

Summary:
Add a proof-of-concept test that uses the new `setup_gnoi_tls_server` TLS fixture
(from `grpc_fixtures.py`) for certificate generation and server configuration, while
keeping the legacy `gnmi_get` helper (py_gnmicli) for the actual gNMI Get call.

This is a stepping stone toward fully migrating gNMI tests to the new grpcurl-based
infrastructure. The full migration is blocked by a gRPC reflection bug in the
`openconfig/gnmi` dependency (sonic-net/sonic-gnmi#601).

### Type of change

- [x] New Test case
    - [ ] Skipped for non-supported platforms

### Back port request

### Approach
#### What is the motivation for this PR?

The existing gNMI test fixtures (`setup_gnmi_server`) have certificate verification
failures due to clock skew. The new `setup_gnoi_tls_server` fixture generates certs
backdated by 1 day to handle this. This PR validates that the new TLS fixture works
for gNMI tests, not just gNOI.

#### How did you do it?

- Created `test_gnmi_configdb_new.py` with one Get test case
- Imported `setup_gnoi_tls_server` and `ptf_grpc` fixtures from `grpc_fixtures.py`
  (following the same pattern as `gnxi/test_gnoi_system.py`)
- Added a `setup_legacy_cert_paths` fixture that creates symlinks from the new cert
  paths (`/etc/ssl/certs/gnmi*.cer`) to the legacy paths (`/root/gnmiCA.pem`,
  `/root/gnmiclient.crt`, `/root/gnmiclient.key`) expected by `py_gnmicli`
- Used the existing `gnmi_get` helper for the actual gNMI Get call

#### How did you verify/test it?

Ran on local KVM testbed (vms-kvm-t0, vlab-01):
```
make test T=gnmi/test_gnmi_configdb_new.py EXTRA='-u -e "--skip_sanity"'
```
Result: 1 passed in ~70s

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

`any` (same as existing gNMI tests)

### Documentation

N/A
