### PR TITLE
Update gNMI default plaintext port from 8080 to 8082

### DIFF
--- a/spytest/apis/system/gnmi.py
+++ b/spytest/apis/system/gnmi.py
@@ -42,7 +42,7 @@ def gnmi_get(dut, xpath, **kwargs):
     gnmi_debug(dut)
     credentails = st.get_credentials(dut)
     ip_address = kwargs.get('ip_address', '127.0.0.1')
-    port = kwargs.get('port', '8080')
+    port = kwargs.get('port', '8082')
     insecure = kwargs.get('insecure', '')
     skip_tmpl = kwargs.get('skip_tmpl', False)
     username = kwargs.get('username', credentails[0])
@@ -103,7 +103,7 @@ def gnmi_set(dut, xpath, json_content, **kwargs):
     gnmi_debug(dut)
     credentails = st.get_credentials(dut)
     ip_address = kwargs.get('ip_address', '127.0.0.1')
-    port = kwargs.get('port', '8080')
+    port = kwargs.get('port', '8082')
     insecure = kwargs.get('insecure', '')
     username = kwargs.get('username', credentails[0])
     password = kwargs.get('password', credentails[3])
@@ -174,7 +174,7 @@ def gnmi_cli(dut, **kwargs):
     credentails = st.get_credentials(dut)
     query_type = kwargs.get('query_type', 'stream')
     ip_address = kwargs.get('ip_address', '127.0.0.1')
-    port = kwargs.get('port', '8080')
+    port = kwargs.get('port', '8082')
     gnmi_utils_path = kwargs.get('gnmi_utils_path', '/tmp')
     if not docker_command:
         st.log("Docker command not found ..")
@@ -261,7 +261,7 @@ def dialout_server_cli(**kwargs):
     :return:
     """
 
-    port = kwargs.get('port', '8080')
+    port = kwargs.get('port', '8082')
     cli_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'spytest', 'gnmi', "dialout_server_cli"))
     if not os.path.exists(cli_path):
         st.log("{} command not found ..".format(cli_path))
@@ -491,7 +491,7 @@ def gnmi_delete(dut, xpath, **kwargs):
     gnmi_debug(dut)
     st.log("Performing GNMI DELETE OPERATION ...")
     ip_address = kwargs.get('ip_address', '127.0.0.1')
-    port = kwargs.get('port', '8080')
+    port = kwargs.get('port', '8082')
     insecure = kwargs.get('insecure', '')
     credentails = st.get_credentials(dut)
     username = kwargs.get('username', credentails[0])
@@ -586,7 +586,7 @@ def _run_gnmi_command(command, pid=False):
 def _prepare_gnmi_command(dut, xpath, **kwargs):
     credentials = st.get_credentials(dut)
     ip_address = kwargs.get('ip_address', '127.0.0.1')
-    port = kwargs.get('port', '8080')
+    port = kwargs.get('port', '8082')
     insecure = kwargs.get('insecure', '')
     username = kwargs.get('username', credentials[0])
     password = kwargs.get('password', credentials[3])

--- a/spytest/spytest/gnmi/__init__.py
+++ b/spytest/spytest/gnmi/__init__.py
@@ -19,7 +19,7 @@ class gNMI(object):
         self.ip = None
         self.inSecure = True
 
-    def configure(self, ip=None, port=8080, targetName=None, username='admin',
+    def configure(self, ip=None, port=8082, targetName=None, username='admin',
                   password=None, ca=None, cert=None, inSecure=True, noTls=False,
                   timeout=10, params=None):
         self.target_name = targetName
@@ -37,7 +37,7 @@ class gNMI(object):
             self.reinit(ip, port=port)
         return self
 
-    def reinit(self, ip, port=8080):
+    def reinit(self, ip, port=8082):
         self.ip = ip.decode('utf-8') if isinstance(ip, bytes) else str(ip)
         self.port = int(port)
         self.target_addr = "{}:{}".format(self.ip, self.port)

--- a/spytest/spytest/gnmi/conf.yaml
+++ b/spytest/spytest/gnmi/conf.yaml
@@ -1,6 +1,6 @@
 parameters:
     host:  10.11.97.10
-    port:  8080
+    port:  8082
     ca: ~
     cert: ~
     username: ~

--- a/spytest/spytest/net.py
+++ b/spytest/spytest/net.py
@@ -453,7 +453,7 @@ class Net(object):
         access = self._get_dev_access(devname)
         self.gnmi.update({devname: gNMI(logger=self.logger, devName=devname)})
         self.gnmi[devname].configure(ip=devinfo.get('gnmi_ip', access.get('ip')),
-                                     port=devinfo.get('gnmi_port', 8080),
+                                     port=devinfo.get('gnmi_port', 8082),
                                      username=devinfo.get('gnmi_username', access['username']),
                                      password=devinfo.get('gnmi_password', access['password']))
 

--- a/tests/common/grpc_config.py
+++ b/tests/common/grpc_config.py
@@ -29,7 +29,7 @@ class GrpcCertificateConfig:
 
     # Default gRPC connection settings
     DEFAULT_TLS_PORT = 50052
-    DEFAULT_PLAINTEXT_PORT = 8080
+    DEFAULT_PLAINTEXT_PORT = 8082
 
     @classmethod
     def get_dut_cert_paths(cls) -> Dict[str, str]:

--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -102,7 +102,7 @@ class GNMIEnvironment(object):
                 config = cfg_facts.get('TELEMETRY', {}).get('gnmi', {})
 
             if config:
-                self.gnmi_port = int(config.get('port', 8080))
+                self.gnmi_port = int(config.get('port', 8082))
                 client_auth = config.get('client_auth', 'false').lower()
                 self.use_tls = client_auth != 'false'
                 logger.info(f"Found CONFIG_DB {self.gnmi_config_table} config: "
@@ -130,7 +130,7 @@ class GNMIEnvironment(object):
             logger.warning(f"Failed to detect from running process: {e}")
 
         # Final fallback: use standard defaults
-        self.gnmi_port = 8080
+        self.gnmi_port = 8082
         self.use_tls = False
         logger.info(f"Using default config: port={self.gnmi_port}, tls={self.use_tls}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -301,7 +301,7 @@ def pytest_addoption(parser):
     # gnmi connection options      #
     ##############################
     # The gNMI target port number to connect to the DUT gNMI server.
-    parser.addoption("--gnmi_port", action="store", default="8080", type=str,
+    parser.addoption("--gnmi_port", action="store", default="8082", type=str,
                      help="gNMI target port number")
     parser.addoption("--gnmi_insecure", action="store_true", default=True,
                      help="Use insecure connection to gNMI target")

--- a/tests/zmq/test_gnmi_zmq.py
+++ b/tests/zmq/test_gnmi_zmq.py
@@ -78,7 +78,7 @@ def enable_zmq(duthost):
 
 def gnmi_set(duthost, ptfhost, delete_list, update_list, replace_list):
     ip = duthost.mgmt_ip
-    port = 8080
+    port = 8082
     cmd = '/root/env-python3/bin/python /root/gnxi/gnmi_cli_py/py_gnmicli.py '
     cmd += '--timeout 30 --notls '
     cmd += '--notls '
@@ -121,7 +121,7 @@ def test_gnmi_zmq(duthosts,
                   enable_zmq):
     duthost = duthosts[rand_one_dut_hostname]
 
-    command = 'ps -auxww | grep "/usr/sbin/telemetry -logtostderr --noTLS --port 8080"'
+    command = 'ps -auxww | grep "/usr/sbin/telemetry -logtostderr --noTLS --port 8082"'
     gnmi_process = duthost.shell(command, module_ignore_errors=True)["stdout"]
     logger.debug("gnmi_process: {}".format(gnmi_process))
 


### PR DESCRIPTION
## Problem
The gNMI container default port is changing from 8080 to 8082 to avoid collision with the telemetry container. Test defaults need to match.

## Change
Update all gNMI plaintext port defaults from 8080 to 8082 across test infrastructure.

## Files Changed
- `tests/common/grpc_config.py` — `DEFAULT_PLAINTEXT_PORT` constant
- `tests/common/helpers/gnmi_utils.py` — GNMIEnvironment fallback defaults
- `tests/conftest.py` — `--gnmi_port` CLI argument default
- `tests/zmq/test_gnmi_zmq.py` — hardcoded port and process grep
- `spytest/spytest/gnmi/__init__.py` — configure/reinit defaults
- `spytest/spytest/gnmi/conf.yaml` — YAML config
- `spytest/apis/system/gnmi.py` — gnmi_get/gnmi_set/gnmi_cli defaults
- `spytest/spytest/net.py` — device connection default