### PR TITLE
Fix pygnmi subscription shutdown

### DIFF
--- a/tests/common/pygnmi_client.py
+++ b/tests/common/pygnmi_client.py
@@ -12,6 +12,7 @@ request surface.
 """
 import logging
 import os
+import sys
 import time
 from collections.abc import Iterable, Iterator
 from enum import StrEnum
@@ -510,24 +511,78 @@ class PygnmiClient:
             PygnmiClientTimeoutError: If a per-call deadline fires or ONCE never
                 sends sync_response.
         """
+        subscriber = None
+        close_subscriber = None
         try:
             gc = self._ensure_client()
             subscriber = gc.subscribe2(subscribe=request, target=target,
                                        extension=extension)
-            try:
-                if mode == SubscribeMode.ONCE:
-                    yield from self._iter_once(subscriber)
-                elif mode == SubscribeMode.POLL:
-                    yield from self._iter_poll(subscriber, poll_count, poll_interval)
-                else:
-                    yield from self._iter_stream(subscriber, collect_seconds, count)
-            finally:
-                subscriber.close()
+            close_subscriber = self._prepare_subscription_shutdown(subscriber)
+            if mode == SubscribeMode.ONCE:
+                yield from self._iter_once(subscriber)
+            elif mode == SubscribeMode.POLL:
+                yield from self._iter_poll(subscriber, poll_count, poll_interval)
+            else:
+                yield from self._iter_stream(subscriber, collect_seconds, count)
         except (grpc.RpcError, grpc.FutureTimeoutError, gNMIException,
                 TimeoutError, PygnmiClientError) as exc:
             raise self._map_error(exc, "subscribe") from exc
         finally:
-            self.close()
+            if close_subscriber is not None:
+                close_subscriber()
+            else:
+                self.close()
+
+    def _prepare_subscription_shutdown(self, subscriber):
+        """Return a closer that drains pygnmi's receiver thread without noise.
+
+        pygnmi 0.8.15 cannot cancel its internal Subscribe call directly. Its
+        subscriber closes only the request iterator, leaving the receive thread
+        blocked until the channel closes. Marking that wrapper-owned shutdown
+        lets us ignore only its expected terminal RPC error and join the thread
+        before returning to the test.
+        """
+        thread = getattr(subscriber, "_subscribe_thread", None)
+        closing = [False]
+
+        if thread is not None and hasattr(thread, "_invoke_excepthook"):
+            invoke_excepthook = thread._invoke_excepthook
+
+            def invoke_subscription_excepthook(thread):
+                error = sys.exc_info()[1]
+                if closing[0] and self._is_expected_subscription_shutdown(error):
+                    logger.debug("Ignoring expected gNMI subscription shutdown: %s", error)
+                    return
+                invoke_excepthook(thread)
+
+            thread._invoke_excepthook = invoke_subscription_excepthook
+
+        def close_subscriber():
+            closing[0] = True
+            try:
+                subscriber.close()
+            finally:
+                self.close()
+                if thread is not None:
+                    thread.join(self.timeout)
+                    if thread.is_alive():
+                        raise PygnmiClientTimeoutError(
+                            "gNMI subscription receiver did not stop after channel close")
+
+        return close_subscriber
+
+    @staticmethod
+    def _is_expected_subscription_shutdown(error):
+        """Return whether an RPC error is caused by wrapper-owned shutdown."""
+        if not isinstance(error, grpc.RpcError):
+            return False
+        code = error.code()
+        details = (error.details() or "").lower()
+        channel_closed = (code == grpc.StatusCode.CANCELLED
+                          and details == "channel closed!")
+        queue_disposed = (code == grpc.StatusCode.INVALID_ARGUMENT
+                          and details == "queue: disposed")
+        return channel_closed or queue_disposed
 
     def _iter_stream(self, subscriber, collect_seconds, count=None):
         """

--- a/tests/gnmi/test_pygnmi_client.py
+++ b/tests/gnmi/test_pygnmi_client.py
@@ -1,5 +1,8 @@
 """Integration tests for the PygnmiClient gNMI client via the gnmi_tls fixture."""
 import logging
+import threading
+
+import grpc
 import pytest
 
 from tests.common.fixtures.grpc_fixtures import gnmi_tls  # noqa: F401
@@ -329,3 +332,116 @@ def test_get_requires_paths():
     """Test get() rejects an empty path list before connecting."""
     with pytest.raises(PygnmiClientCallError, match="at least one path"):
         _offline_client().get([])
+
+
+@pytest.mark.parametrize(
+    "status, details",
+    [
+        (grpc.StatusCode.CANCELLED, "Channel closed!"),
+        (grpc.StatusCode.INVALID_ARGUMENT, "queue: disposed"),
+    ],
+)
+def test_subscribe_closes_receiver_without_unhandled_exception(monkeypatch, status, details):
+    """Test wrapper-owned shutdown absorbs pygnmi's terminal RPC errors."""
+    channel_closed = threading.Event()
+    unhandled = []
+
+    class ExpectedShutdownError(grpc.RpcError):
+        def code(self):
+            return status
+
+        def details(self):
+            return details
+
+    class FakeSubscriber:
+        def __init__(self):
+            self._subscribe_thread = threading.Thread(target=self._receive)
+            self._subscribe_thread.start()
+
+        def _receive(self):
+            channel_closed.wait(timeout=1)
+            raise ExpectedShutdownError()
+
+        def get_update(self, timeout):
+            return {"update": {}}
+
+        def close(self):
+            self._subscribe_thread.join(0.01)
+
+    class FakeGnmiClient:
+        def connect(self):
+            pass
+
+        def subscribe2(self, **kwargs):
+            self.subscriber = FakeSubscriber()
+            return self.subscriber
+
+        def close(self):
+            channel_closed.set()
+
+    fake_client = FakeGnmiClient()
+    monkeypatch.setattr("tests.common.pygnmi_client.gNMIclient", lambda **kwargs: fake_client)
+    monkeypatch.setattr(threading, "excepthook", lambda args: unhandled.append(args.exc_value))
+
+    subscription = _offline_client().subscribe("path", collect_seconds=30)
+    result = next(subscription)
+    subscription.close()
+
+    assert result == {"update": {}}
+    assert not fake_client.subscriber._subscribe_thread.is_alive()
+    assert unhandled == []
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        RuntimeError("unexpected receiver failure"),
+        type(
+            "UnexpectedCancellation",
+            (grpc.RpcError,),
+            {
+                "code": lambda self: grpc.StatusCode.CANCELLED,
+                "details": lambda self: "server cancelled request",
+            },
+        )(),
+    ],
+)
+def test_subscribe_reports_unexpected_receiver_exception(monkeypatch, error):
+    """Test wrapper-owned shutdown does not hide unrelated receiver errors."""
+    channel_closed = threading.Event()
+    unhandled = []
+
+    class FakeSubscriber:
+        def __init__(self):
+            self._subscribe_thread = threading.Thread(target=self._receive)
+            self._subscribe_thread.start()
+
+        def _receive(self):
+            channel_closed.wait(timeout=1)
+            raise error
+
+        def get_update(self, timeout):
+            return {"update": {}}
+
+        def close(self):
+            self._subscribe_thread.join(0.01)
+
+    class FakeGnmiClient:
+        def connect(self):
+            pass
+
+        def subscribe2(self, **kwargs):
+            self.subscriber = FakeSubscriber()
+            return self.subscriber
+
+        def close(self):
+            channel_closed.set()
+
+    fake_client = FakeGnmiClient()
+    monkeypatch.setattr("tests.common.pygnmi_client.gNMIclient", lambda **kwargs: fake_client)
+    monkeypatch.setattr(threading, "excepthook", lambda args: unhandled.append(args.exc_value))
+
+    list(_offline_client().subscribe("path", count=1, collect_seconds=1))
+
+    assert len(unhandled) == 1
+    assert unhandled[0] is error


### PR DESCRIPTION
## Summary

Stacked follow-up for sonic-net/sonic-mgmt#26013. This is for sharing/review and is not mergeable independently.

- close the pygnmi channel before joining its blocked receiver thread
- suppress only the two terminal RPC errors observed during wrapper-owned shutdown
- keep unexpected receiver failures visible
- add focused exhaustion/explicit-close regression coverage

## Dependency note

pygnmi 0.8.15 exposes neither its Subscribe RPC nor a deterministic cancel/join method. This workaround is scoped to the exact subscriber thread rather than installing a process-global exception filter. It should be removed when the dependency provides a public cancellation seam.

## Validation

Local KVM, exact stacked checkout:

```text
./run_tests.sh -n vms-kvm-t0 -c gnmi/test_pygnmi_client.py \
  -i ../ansible/veos_vtb -f ../ansible/vtestbed.yaml \
  -u -e "--skip_sanity"
```

Three final full-module runs after tightening the tests:

- 18 passed in 16:02
- 18 passed in 16:02
- 18 passed in 15:51
- JUnit: 0 failures, 0 errors
- no `PytestUnhandledThreadExceptionWarning`

Focused shutdown matrix: 4 passed. `py_compile` and flake8 (excluding the repository-documented E501 exception and pre-existing W503 style) pass.

Related: sonic-net/sonic-mgmt#26384.